### PR TITLE
Add rounded cells to denote bonuses

### DIFF
--- a/Score Keeper of Nottingham/Models/Player.swift
+++ b/Score Keeper of Nottingham/Models/Player.swift
@@ -87,6 +87,14 @@ struct Player: Identifiable {
     var score: Int {
         return scoreData.score
     }
+    
+    var hasBonuses: Bool {
+        return scoreData.hasBonuses
+    }
+    
+    var earnedBonuses: [String] {
+        return scoreData.earnedBonuses
+    }
 }
 
 extension Player: Equatable {

--- a/Score Keeper of Nottingham/Models/PlayerScore.swift
+++ b/Score Keeper of Nottingham/Models/PlayerScore.swift
@@ -32,6 +32,30 @@ struct PlayerScore {
     let isChickenKing: Bool
     let isChickenQueen: Bool
     var isWinner = false
+
+    var hasBonuses: Bool {
+        return isAppleKing || isAppleQueen ||
+            isCheeseKing || isCheeseQueen ||
+            isBreadKing || isBreadQueen ||
+            isChickenKing || isChickenQueen
+    }
+
+    var earnedBonuses: [String] {
+        let bonusMap = [
+            "🍎 K" : isAppleKing,
+            "🍎 Q" : isAppleQueen,
+            "🧀 K" : isCheeseKing,
+            "🧀 Q" : isCheeseQueen,
+            "🍞 K" : isBreadKing,
+            "🍞 Q" : isBreadQueen,
+            "🐓 K" : isChickenKing,
+            "🐓 Q" : isChickenQueen,
+        ]
+
+        return bonusMap.compactMap { bonus, bonusEarned in
+            bonusEarned ? bonus : nil
+        }.sorted()
+    }
 }
 
 extension PlayerScore: Equatable {

--- a/Score Keeper of Nottingham/Views/PlayerRow.swift
+++ b/Score Keeper of Nottingham/Views/PlayerRow.swift
@@ -8,30 +8,67 @@
 
 import SwiftUI
 
+private let SILVER_COLOR = Color(red: 128 / 255, green: 128 / 255, blue: 128 / 255)
+private let GOLD_COLOR = Color(red: 212 / 255, green: 175 / 255, blue: 55 / 255)
+
 let dummyPlayer = Player(name: "John", appleCount: 6, cheeseCount: 3, breadCount: 3, chickenCount: 1, pepperCount: 3, meadCount: 2, silkCount: 2, crossbowCount: 1, coinageValue: 10, greenApplesCount: 0, goldenApplesCount: 0, goudaCheeseCount: 0, blueCheseCount: 0, ryeBreadCount: 0, pumpernickelCount: 0, dualChickenCount: 0,
-                              scoreData: PlayerScore(score: 131,
-                              isAppleKing: true, isAppleQueen: false,
-                              isCheeseKing: false, isCheeseQueen: false,
-                              isBreadKing: false, isBreadQueen: true,
-                              isChickenKing: false, isChickenQueen: false,
-                              isWinner: false)
+                         scoreData: PlayerScore(score: 131,
+                                                isAppleKing: true, isAppleQueen: false,
+                                                isCheeseKing: false, isCheeseQueen: false,
+                                                isBreadKing: false, isBreadQueen: true,
+                                                isChickenKing: false, isChickenQueen: false,
+                                                isWinner: false)
 )
 
 struct PlayerRow: View {
     @Binding var player: Player
     
     var body: some View {
-        HStack{
-            Text(player.name)
-            Spacer()
-            Text(String(player.scoreData.score))
+        VStack {
+            HStack{
+                Text(player.name)
+                Spacer()
+                Text(String(player.scoreData.score))
+            }.padding(.bottom, 4)
+            if player.hasBonuses {
+                BonusesView(bonuses: player.earnedBonuses)
+            }
         }
     }
 }
 
-//struct PlayerRow_Previews: PreviewProvider {
-//    static var previews: some View {
-//        PlayerRow(player: dummyPlayer)
-//            .previewLayout(.fixed(width: 300, height: 70))
-//    }
-//}
+struct BonusesView: View {
+    let bonuses: [String]
+    
+    var body: some View {
+        VStack() {
+//            ScrollView(.horizontal, showsIndicators: false) {
+                HStack() {
+                    ForEach(bonuses, id: \.self) { bonus in
+                        let color = bonus.contains("K") ? GOLD_COLOR : SILVER_COLOR
+                        BonusCell(text: bonus, color: color)
+                    }
+                    Spacer()
+                }
+//            }
+        }
+    }
+}
+
+struct BonusCell: View {
+    let text: String
+    let color: Color
+    
+    var body: some View {
+        Text(text)
+            .fontWeight(.bold)
+            .foregroundColor(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .font(.system(size: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(color, lineWidth: 2)
+            )
+    }
+}


### PR DESCRIPTION
Closes: #4 

This adds a functional view to the player row. King and Queen have been abbreviated to "K" and "Q" which ensures if a player has all 4 bonuses, it does not overflow the screen. A wrapping horizontal stack would be preferable, but is beyond the scope of this PR.

It is worth considering if we should show these icons for bonuses on the player detail page.